### PR TITLE
ignore KMP packages with "filename-too-long-for-joliet"

### DIFF
--- a/build-compare.changes
+++ b/build-compare.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 21 12:57:57 UTC 2015 - seife+obs@b1-systems.com
+
+- avoid -kmp packages with "filename-too-long-for-joliet"
+  triggering constant republishing
+
+-------------------------------------------------------------------
 Wed Jul 15 09:50:58 UTC 2015 - olaf@aepfle.de
 
 - 2015.07.15

--- a/same-build-result.sh
+++ b/same-build-result.sh
@@ -117,6 +117,13 @@ if test -n "$OTHERDIR"; then
     # Remove release from files
     sort -u $OLDDIR/rpmlint.log|sed -e "s,$ver_rel1,@VERSION@-@RELEASE@,g" -e "s|/tmp/rpmlint\..*spec|.spec|g" > $file1
     sort -u $OTHERDIR/rpmlint.log|sed -e "s,$ver_rel2,@VERSION@-@RELEASE@,g" -e "s|/tmp/rpmlint\..*spec|.spec|g"  > $file2
+    ### kmp's are strange:
+    # the correct way would be to find the versions of -kmp- packages and ignore them, but this will do, too.
+    # example: this one leads to constant republishing of virtualbox for every build.
+    # -virtualbox-guest-kmp-default.x86_64: W: filename-too-long-for-joliet virtualbox-guest-kmp-default-5.0.2_k3.16.7_24-177.d_l_ocaml.2.x86_64.rpm
+    # +virtualbox-guest-kmp-default.x86_64: W: filename-too-long-for-joliet virtualbox-guest-kmp-default-5.0.2_k3.16.7_24-178.d_l_ocaml.1.x86_64.rpm
+    sed -i -e "/W: filename-too-long-for-joliet/s,\(^.*-kmp-.*-kmp-\).*$,\1," $file1
+    sed -i -e "/W: filename-too-long-for-joliet/s,\(^.*-kmp-.*-kmp-\).*$,\1," $file2
     if ! cmp -s $file1 $file2; then
       echo "rpmlint.log files differ:"
       diff -u $file1 $file2 |head -n 20


### PR DESCRIPTION
VirtualBox stuff gets constantly republished due to "filename too long for Joliet" of the kmp packages. Just ignore that string for KMP packages.