### PR TITLE
pkg-diff.sh: Don't fall back from binary diff to ELF diff

### DIFF
--- a/pkg-diff.sh
+++ b/pkg-diff.sh
@@ -726,6 +726,7 @@ check_single_file()
          if ! diff_two_files; then
            return 1
          fi
+         return 0
        fi
        filter_disasm $file1
        filter_disasm $file2


### PR DESCRIPTION
If the two ELF files are identical according to diff_two_files()
we continue with ELF file examination, in the architecture UNKNOWN case
comparing identical objdump outputs $file1 and $file2. This leads to:

  only difference was in build-id or gnu_debuglink, GOOD.

Always return immediately after after diff_two_files() to avoid this.

Fixes #12.

Signed-off-by: Andreas Färber <afaerber@suse.de>