### PR TITLE
Ignore .gnu_debugdata section when comparing ELF files.

### DIFF
--- a/build-compare.changes
+++ b/build-compare.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Nov  7 03:54:00 UTC 2016 - ol@infoserver.lv
+
+- Ignore .gnu_debugdata section when comparing ELF files.
+
+-------------------------------------------------------------------
 Wed Oct 12 16:40:24 CEST 2016 - ro@suse.de
 
 - pkg-diff.sh: use option --speed-large-files for diffing

--- a/pkg-diff.sh
+++ b/pkg-diff.sh
@@ -777,8 +777,8 @@ check_single_file()
        fi
        echo "" >$file1
        echo "" >$file2
-       # Don't compare .build-id and .gnu_debuglink sections
-       sections="$($OBJDUMP -s new/$file | grep "Contents of section .*:" | sed -r "s,.* (.*):,\1,g" | grep -v -e "\.build-id" -e "\.gnu_debuglink" | tr "\n" " ")"
+       # Don't compare .build-id, .gnu_debuglink and .gnu_debugdata sections
+       sections="$($OBJDUMP -s new/$file | grep "Contents of section .*:" | sed -r "s,.* (.*):,\1,g" | grep -v -e "\.build-id" -e "\.gnu_debuglink" -e "\.gnu_debugdata" | tr "\n" " ")"
        for section in $sections; do
           $OBJDUMP -s -j $section old/$file | sed "s,^old/,," > $file1
           $OBJDUMP -s -j $section new/$file | sed "s,^new/,," > $file2
@@ -789,7 +789,7 @@ check_single_file()
           fi
        done
        if test -z "$elfdiff"; then
-          echo "$file: only difference was in build-id or gnu_debuglink, GOOD."
+          echo "$file: only difference was in build-id, gnu_debuglink or gnu_debugdata, GOOD."
           return 0
        fi
        return 1


### PR DESCRIPTION
This section contains `build-id` inside, so it changes with every build.