### PR TITLE
Treat .egg files as zip

### DIFF
--- a/pkg-diff.sh
+++ b/pkg-diff.sh
@@ -548,7 +548,7 @@ check_single_file()
        done
        return $ret
        ;;
-    *.zip|*.jar|*.war)
+    *.zip|*.egg|*.jar|*.war)
        for dir in old new ; do
           (
              cd $dir


### PR DESCRIPTION
This helps to ignore timestamp diffs in python-etude and deluge packages