### PR TITLE
Ignore value of Release header when comparing spec files

### DIFF
--- a/build-compare.changes
+++ b/build-compare.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Aug 28 20:14:53 UTC 2018 - ol@infoserver.lv
+
+- Ignore value of Release header when comparing spec files
+
+-------------------------------------------------------------------
 Fri Jul  6 14:01:17 UTC 2018 - olaf@aepfle.de
 
 - pkg-diff: fix diff returning 0

--- a/srpm-check.sh
+++ b/srpm-check.sh
@@ -69,8 +69,8 @@ check_single_file()
   local file=$1
   case $file in
     *.spec)
-       sed -i -e "s,Release:.*${ver_rel_old}$,Release: @RELEASE@," old/$file
-       sed -i -e "s,Release:.*${ver_rel_new}$,Release: @RELEASE@," new/$file
+       sed -i -e 's,^Release:.*$,Release: @RELEASE@,' old/$file
+       sed -i -e 's,^Release:.*$,Release: @RELEASE@,' new/$file
        if ! cmp -s old/$file new/$file; then
          echo "$file differs (spec file)"
          diff -u old/$file new/$file | head -n 20


### PR DESCRIPTION
Replacing release taken from source RPM metadata with `@RELEASE@` placeholder in `Release:` header of spec file before comparing doesn't work if there is a variable substitution in this header.

For example, you may have this in your project config:
```
Release: <CI_CNT>%%{?dist}.<B_CNT>
```
This will cause `Release:` header look like this in generated spec file:
```
Release: 1%{?dist}.2
```
whereas release extracted from source RPM metadata will look like `1.fc27.2`, and these substitutions will not work:
```sh
sed -i -e "s,Release:.*${ver_rel_old}$,Release: @RELEASE@," old/$file
sed -i -e "s,Release:.*${ver_rel_new}$,Release: @RELEASE@," new/$file
```
This change makes comparing srpm files to ignore value of `Release:` header. This value is generated from project config anyway.