### PR TITLE
pkg-diff: fix diff returning 0

### DIFF
--- a/pkg-diff.sh
+++ b/pkg-diff.sh
@@ -831,7 +831,7 @@ check_single_file()
     ELF*[LM]SB\ pie\ executable*|\
     setuid\ ELF*[LM]SB\ pie\ executable*)
        $OBJDUMP -d --no-show-raw-insn old/$file > $file1
-       ret=$?
+       local ret=$?
        $OBJDUMP -d --no-show-raw-insn new/$file > $file2
        if test ${ret}$? != 00 ; then
          # objdump has no idea how to handle it


### PR DESCRIPTION
without this patch, pkg-diff -a returned 0 in some cases
and reported rpms as identical
when actually one file differed and another file didnt

to reproduce:
 ```bash
cd /suse/bwiedemann/Export/temp/build-compare/
bash /home/bernhard/code/cvs/build-compare/pkg-diff.sh -a ?.rpm
```
