### PR TITLE
Fix cmp_rpm_meta to not return 0 on diff

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -175,6 +175,7 @@ function comp_file()
         rm $2 $3 $4 $5
         return 1
       fi
+      difffound=1
     fi
     return 0
 }
@@ -291,6 +292,7 @@ function cmp_rpm_meta ()
           if test -z "$check_all"; then
             return 1
           fi
+          difffound=1
           ;;
         # Every other package is allowed to have a different RELEASE
         *) ;;
@@ -340,6 +342,7 @@ function cmp_rpm_meta ()
     fi
     #
     rm $file1 $file2
+    [ "$difffound" = 1 ] && RES=1
     return $RES
 }
 

--- a/functions.sh
+++ b/functions.sh
@@ -266,16 +266,14 @@ function cmp_rpm_meta ()
 
     set_regex
 
-    # Check the whole spec file at first, return 0 immediately if the
+    # Check the whole spec file at first, return 0 immediately if they
     # are the same.
     cat $rpm_meta_old | trim_release_old > $file1
     cat $rpm_meta_new | trim_release_new > $file2
     echo "comparing the rpm tags of $name_new"
     if diff -au $file1 $file2; then
-      if test -z "$check_all"; then
-        rm $file1 $file2 $rpm_meta_old $rpm_meta_new
-        return 0
-      fi
+      rm $file1 $file2 $rpm_meta_old $rpm_meta_new
+      return 0
     fi
 
     get_value QF_TAGS $rpm_meta_old > $file1

--- a/tests/pkg-diff-test.sh
+++ b/tests/pkg-diff-test.sh
@@ -14,9 +14,13 @@ it_finds_text_diff()
     ! $p rpms/stringtext-1-[02].*.rpm
 }
 
-it_prints_md5_diff()
+it_prints_md5_or_sha256_diff()
 {
-    $p rpms/stringtext-1-[02].*.rpm | grep '^-/usr/share/doc.*/stringtext[^/]*/string.txt f447b20a7fcbf53a5d5be013ea0b1' #= echo 123456|md5sum
+    #= echo 123456|md5sum
+    #= echo 123456|sha256sum
+    $p rpms/stringtext-1-[02].*.rpm | grep \
+        -e '^-/usr/share/doc.*/stringtext[^/]*/string.txt f447b20a7fcbf53a5d5be013ea0b1' \
+        -e '^-/usr/share/doc.*/stringtext[^/]*/string.txt e150a1ec81e8e93e1eae2c3a77e66ec6dbd6a3b460f89c1d08aecf422ee401a0'
 }
 
 it_prints_text_diff()

--- a/tests/pkg-diff-test.sh
+++ b/tests/pkg-diff-test.sh
@@ -11,7 +11,7 @@ p=$basedir/pkg-diff.sh
 it_finds_text_diff()
 {
     $p rpms/stringtext-1-[01].*.rpm
-    ! $p rpms/stringtext-1-[02].*.rpm
+    ! $p rpms/stringtext-1-[02].*.rpm || return 1
 }
 
 it_prints_md5_or_sha256_diff()
@@ -31,13 +31,13 @@ it_prints_text_diff()
 
 it_finds_diff_even_with_identical_files()
 {
-    ! $p -a rpms/stringtext-1-1[01].*.rpm
-    ! $p -a rpms/stringtext-1-1[02].*.rpm
-    ! $p -a rpms/stringtext-1-1[12].*.rpm
+    ! $p -a rpms/stringtext-1-1[01].*.rpm || return 1
+    ! $p -a rpms/stringtext-1-1[02].*.rpm || return 1
+    ! $p -a rpms/stringtext-1-1[12].*.rpm || return 1
 }
 
 it_reports_missing_files()
 {
-    ! $p -a rpms/stringtext-1-{2,12}.*.rpm
+    ! $p -a rpms/stringtext-1-{2,12}.*.rpm || return 1
     $p -a rpms/stringtext-1-{2,12}.*.rpm | grep 'string2.txt differs'
 }

--- a/tests/pkg-diff-test.sh
+++ b/tests/pkg-diff-test.sh
@@ -41,3 +41,9 @@ it_reports_missing_files()
     ! $p -a rpms/stringtext-1-{2,12}.*.rpm || return 1
     $p -a rpms/stringtext-1-{2,12}.*.rpm | grep 'string2.txt differs'
 }
+
+it_reports_differing_rpm_tags()
+{
+    ! $p -a rpms/stringtext-1-{1,3}.*.rpm || return 1
+    $p -a rpms/stringtext-1-{1,3}.*.rpm | grep '^+bar 0'
+}

--- a/tests/specs/build.sh
+++ b/tests/specs/build.sh
@@ -10,7 +10,13 @@ stringtext()
 {
     n=$1
     string=$2
-    rpmbuild -bb -D '%outfile string.txt' -D "%outcmd echo $string > %outfile" stringtext.spec || exit 15
+    meta=$3
+    [ -z "$meta" ] && meta="Provides: foo"
+    rpmbuild -bb \
+        -D '%outfile string.txt' \
+        -D "%outcmd echo $string > %outfile" \
+        -D "%metadata $meta" \
+        stringtext.spec || exit 15
     mv ~/rpmbuild/RPMS/x86_64/stringtext-1-0.x86_64.rpm $r/stringtext-1-$n.x86_64.rpm
 }
 
@@ -27,6 +33,7 @@ stringtext2()
 stringtext 0 123456
 stringtext 1 123456
 stringtext 2 X98765
+stringtext 3 123456 "Provides: bar"
 stringtext2 10 123456 789
 stringtext2 11 123456 123
 stringtext2 12 X98765 123

--- a/tests/specs/stringtext.spec
+++ b/tests/specs/stringtext.spec
@@ -17,6 +17,7 @@ Version:        1
 Release:        0
 License:        MIT
 Summary:        build-compare test rpm
+%?metadata
 
 %description
 build-compare test rpm


### PR DESCRIPTION
See `it_reports_differing_rpm_tags` test for a reproducer

Also includes:
* required update of a test to Leap 15.0
* some fixes in other tests
* added regression test for this bug
* code cleanup