### PR TITLE
pkg-diff.sh: Ignore R build timestamp & temp paths

### DIFF
--- a/build-compare.changes
+++ b/build-compare.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 14 13:27:38 UTC 2019 - John Vandenberg <jayvdb@gmail.com>
+
+- pkg-diff.sh: Ignore R build timestamp & temp paths
+  https://github.com/openSUSE/build-compare/pull/34
+
+-------------------------------------------------------------------
 Tue Feb 19 09:30:20 UTC 2019 - olaf@aepfle.de
 
 - javadoc: filter dc.created

--- a/pkg-diff.sh
+++ b/pkg-diff.sh
@@ -752,6 +752,21 @@ check_single_file()
        echo "Ignore $file"
        return 0
        ;;
+    /usr/lib*/R/library/*/DESCRIPTION)
+       # Simulate R CMD INSTALL --built-timestamp=''
+       # Built: R 3.6.1; x86_64-suse-linux-gnu; 2019-08-13 04:19:49 UTC; unix
+       sed -i -e 's|\(Built: [^;]*; [^;]*; \)20[0-9][0-9]-[01][0-9]-[0123][0-9] [012][0-9]:[0-5][0-9]:[0-5][0-9] UTC\(; .*\)$|\1\2|' old/$file new/$file
+       ;;
+    /usr/lib*/R/library/*/Meta/package.rds)
+       # R binary cache of DESCRIPTION
+       echo "Ignore $file"
+       return 0
+       ;;
+    /usr/lib*/R/library/*/R/*.rd[bx])
+       # binary cache of interpreted R code
+       echo "Ignore $file"
+       return 0
+       ;;
     */Linux*Env.Set.sh)
        # LibreOffice files, contains:
        # Generated on: Mon Apr 18 13:19:22 UTC 2011


### PR DESCRIPTION
R DESCRIPTION contains the build timestamp, and
Meta/package.rds is a binary cache of DESCRIPTION.

R/*.rd[bx] are R cache files of the interpreted R code,
and they include temporary paths.  Any change in the R caching
will occur in the R-base packages, and those changes already
trigger other changes in each built package which will ensure
rebuilds of these interpreted R caches.