### PR TITLE
Do not clear ret to not miss diffs

### DIFF
--- a/pkg-diff.sh
+++ b/pkg-diff.sh
@@ -789,6 +789,7 @@ compare_archive()
         : "${REPLY}"
         filelist+=( "${REPLY}" )
       done < 'cn'
+      ret=0
       for f in "${filelist[@]}"
       do
         if ! check_single_file "${file}/${f}"
@@ -801,7 +802,6 @@ compare_archive()
         fi
         watchdog_touch
       done
-      ret=$?
     else
       wprint "$file has different file list"
       diff -u 'co' 'cn'


### PR DESCRIPTION
This bug was introduced in commit b5aa37b

It reported official tigervnc builds as unchanged
even though, 1 file in a .jar always changed.

This PR was done while working on reproducible builds for openSUSE.

```
osc jobhistory openSUSE:Factory/tigervnc/standard/x86_64
2020-05-14 08:11:28  tigervnc new build        unchanged 3m 30s   sheep85:12
2020-05-30 22:36:51  tigervnc new build        succeeded 7m 46s   lamb61:2
2020-07-02 22:42:15  tigervnc source change    succeeded 2m  3s   goat01:3
2020-07-22 20:55:43  tigervnc new build        unchanged 2m 26s   goat05:3
```