### PR TITLE
Make output more diffable and readable

### DIFF
--- a/build-compare.changes
+++ b/build-compare.changes
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------
 Mon Jul 27 06:06:06 UTC 2020 - bwiedemann@suse.de
 
+- Make output more diffable and readable
 - Fix regression in compare_archive
 - Fix unit tests
 

--- a/functions.sh
+++ b/functions.sh
@@ -218,7 +218,7 @@ function unpackage()
 function comp_file()
 {
     echo "comparing $1"
-    if ! diff -au $2 $3; then
+    if ! diff --label old-$1 --label new-$1 -au $2 $3; then
       if test -z "$check_all"; then
         rm $2 $3 $4 $5
         return 1
@@ -320,7 +320,7 @@ function cmp_rpm_meta ()
     cat $rpm_meta_old | trim_release_old > $file1
     cat $rpm_meta_new | trim_release_new > $file2
     echo "comparing the rpm tags of $name_new"
-    if diff -au $file1 $file2; then
+    if diff --label old-rpm-tags --label new-rpm-tags -au $file1 $file2; then
       rm $file1 $file2 $rpm_meta_old $rpm_meta_new
       return 0
     fi

--- a/pkg-diff.sh
+++ b/pkg-diff.sh
@@ -198,6 +198,8 @@ diff_two_files()
   offset=$(( ($offset >> 6) << 6 ))
   length=512
   diff -u \
+    --label "old $file (hex)" \
+    --label "new $file (hex)" \
     <( hexdump -C -s $offset -n $length "old/$file" ) \
     <( hexdump -C -s $offset -n $length "new/$file" ) | $buildcompare_head
   return 1
@@ -901,6 +903,8 @@ check_single_file()
     ELF*[LM]SB\ pie\ executable*|\
     setuid\ ELF*[LM]SB\ pie\ executable*)
       diff --speed-large-files --unified \
+        --label "old $file (disasm)" \
+        --label "new $file (disasm)" \
         <( $OBJDUMP -d --no-show-raw-insn old/$file |
           filter_disasm |
           sed -e "s,old/,," ;
@@ -973,6 +977,8 @@ check_single_file()
       for section in $sections
       do
         diff --unified \
+          --label "old $file (objdump)" \
+          --label "new $file (objdump)" \
           <( $OBJDUMP -s -j $section old/$file |
               sed -e "s,^old/,," ;
               echo "${PIPESTATUS[@]}" > $file1) \


### PR DESCRIPTION
    Without this patch, rpm-tags diffs would contain timestamp and random path
    /tmp/tmp.vLqm0bDVGd/tmp.sQFri37Kxu 2020-07-26 13:01:08.997019837 +0000
    
    and hexdumps would have timestamp and file descriptor
    --- /dev/fd/63 2020-07-26 13:01:10.085023395 +0000
