### PR TITLE
Drop another duration from rpmlint.log

### DIFF
--- a/same-build-result.sh
+++ b/same-build-result.sh
@@ -151,6 +151,7 @@ if test -n "$OTHERDIR"; then
     /: W: python-bytecode-inconsistent-mtime /d
     /: W: filename-too-long-for-joliet /d
     /: I: \(filelist-initialization\|check-completed\) /s| [0-9]\+\.[0-9] s| x.x s|
+    /specfiles checked;/s| [0-9]\+\.[0-9] s$| x.x s|
     " $file1 $file2
     if ! cmp -s $file1 $file2; then
       echo "rpmlint.log files differ:"


### PR DESCRIPTION
Drop another duration from rpmlint.log

Problem was reported in https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/AR4UOT4CNEQYMHBVIMD253HKCEDOO43R/

excessive re-publish due to
```diff
- 4 packages and 0 specfiles checked; 0 errors, 0 warnings, 0 badness; has taken 2.1 s
+ 4 packages and 0 specfiles checked; 0 errors, 0 warnings, 0 badness; has taken 2.2 s
```

Maybe `rpmlint.log` should be completely ignored instead, because it is not part of the rpm.