### PR TITLE
ELF diffing performance improvements

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -320,7 +320,7 @@ function cmp_rpm_meta ()
     trim_release_old < $rpm_meta_old > $file1
     trim_release_new < $rpm_meta_new > $file2
     echo "comparing the rpm tags of $name_new"
-    if diff --label old-rpm-tags --label new-rpm-tags -au $file1 $file2; then
+    if diff --speed-large-files --label old-rpm-tags --label new-rpm-tags -au0 $file1 $file2; then
       rm -rf "$tmpdir"
       return 0
     fi


### PR DESCRIPTION
* Running objdump on old and new in parallel rather than sequentially
* Run diff on sections before doing full assembly dump as sections dump
  is 3-10 times faster than disassembly (so if there is a diff, we can
  skip the much more expensive disassembly)
* Rather than looping over every section individually, dump all the
  sections in one command and then diff it completely

While this makes the error message slightly less exact, it removes a
O(n^2) behavior of the script and reduces runtime on larger comparisons
like libqt5-base by ~ factor 5.