### PR TITLE
Ignore more sections when comparing ELF executable files

### DIFF
--- a/build-compare.changes
+++ b/build-compare.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sat Apr  8 23:58:34 UTC 2023 - Oleg Girko <ol@infoserver.lv>
+
+- Ignore more sections when comparing ELF executable files
+
+-------------------------------------------------------------------
 Fri Nov 25 23:51:35 UTC 2022 - Stefan Brüns <stefan.bruens@rwth-aachen.de>
 
 - Trim "PROVIDES" from source rpms (#59, bsc#1205998)

--- a/pkg-diff.sh
+++ b/pkg-diff.sh
@@ -931,6 +931,8 @@ check_single_file()
             /\.build-id/d
             /\.gnu_debuglink/d
             /\.gnu_debugdata/d
+            /\.note\.package/d
+            /\.note\.go\.buildid/d
             p
           }
         '))


### PR DESCRIPTION
The following ELF sections vary between builds and therefore should be ignored when comparing:
* `.note.package` section contains RPM package version and release,
* `.note.go.buildid` contains Go build ID.