### PR TITLE
Fix filtering compiled Python modules to handle Python >= 3.7

### DIFF
--- a/build-compare.changes
+++ b/build-compare.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed May  3 17:32:18 UTC 2023 - Oleg Girko <ol@infoserver.lv>
+
+- Fix filtering compiled Python modules to handle Python >= 3.7
+
+-------------------------------------------------------------------
 Fri Apr 28 21:21:21 UTC 2023 - olaf@aepfle.de
 
 - remove timestamps from png files

--- a/pkg-diff.sh
+++ b/pkg-diff.sh
@@ -64,7 +64,26 @@ filter_xenefi() {
 }
 
 filter_pyc() {
-   perl -e "open fh, '+<', '$f'; seek fh, 4, SEEK_SET; print fh '0000';"
+   perl -e '
+   my $ts_off = 4;
+   my $f = shift;
+   open fh, "+<", $f;
+   my $data;
+   die "Unexpected EOF while reading $f" if read(fh, $data, 2) < 2;
+   my $magic1 = unpack "v", $data;
+   die "Unexpected EOF while reading $f" if read(fh, $data, 2) < 2;
+   my $magic2 = unpack "v", $data;
+   die "File $f is not a compiled Python module" if $magic2 != 0x0a0d;
+   if ($magic1 >= 3392 && $magic1 < 20000) {
+     $ts_off += 4;
+     die "Unexpected EOF while reading $f" if read(fh, $data, 4) < 4;
+     my $flags = unpack "V", $data;
+     $ts_off += 8 if $flags & 0x1;
+   }
+   seek fh, $ts_off, SEEK_SET;
+   print fh "0000";
+   close fh;
+   ' "$f"
 }
 
 filter_dvi() {


### PR DESCRIPTION
Starting from Python 3.7, timestamp doesn't immediately follow magic number in compiled Python modules.

Instead, there are 32-bit flags after magic number. Then, either timestamp follows flags immediately (if lowest bit of flags is 0), or after 64-bit checksum.

This change fixes `pyc` / `pyo` files filtering to take different timestamp location in Python >= 3.7 into account.