### PR TITLE
debian: mark scripts as executable before installing

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,3 +2,7 @@
 
 %:
 	dh $@
+
+# OBS strips +x from files storage
+execute_before_dh_install:
+	chmod +x $(CURDIR)/*.sh


### PR DESCRIPTION
OBS strips +x from files it stores directly, so they are all lost in https://build.opensuse.org/package/show/openSUSE:Tools/build-compare which results in obs-build not running the compare script, since it checks whether it is executable before running it: https://github.com/openSUSE/obs-build/blob/26e524de588f76e9e4b0b88d0b5467a4713f9e98/build-recipe-dsc#L229

Mark scripts as executable before installing them during the debian package build.